### PR TITLE
Rollout restart deployment

### DIFF
--- a/internal/controller/apiendpoints_controller.go
+++ b/internal/controller/apiendpoints_controller.go
@@ -353,7 +353,7 @@ func (r *ApiEndpointsReconciler) updateKrakendConfigMap(ctx context.Context, k *
 
 	err = r.setCmHashToDeploymentAnnotations(ctx, k, cmHash)
 	if err != nil {
-		return fmt.Errorf("rollout restart Deployment: %v", err)
+		return fmt.Errorf("set cm hash to Deployment annotations: %v", err)
 	}
 
 	return nil
@@ -366,8 +366,11 @@ func (r ApiEndpointsReconciler) setCmHashToDeploymentAnnotations(ctx context.Con
 		Name:      dName,
 		Namespace: k.Namespace,
 	}, d)
-	if err != nil {
+	if client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("get Deployment '%s': %v", dName, err)
+	}
+	if errors.IsNotFound(err) {
+		return nil
 	}
 
 	annotations := d.GetAnnotations()

--- a/internal/controller/apiendpoints_controller_test/apiendpoints_controller_test.go
+++ b/internal/controller/apiendpoints_controller_test/apiendpoints_controller_test.go
@@ -32,6 +32,22 @@ var _ = Describe("ApiEndpoints Controller", func() {
 
 	BeforeEach(func() {
 		Expect(k8sClient.Create(ctx, apiEndpointsDeps.krakend)).Should(Succeed())
+		k := &krakendv1.Krakend{}
+
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(apiEndpointsDeps.krakend), k)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		apiEndpointsDeps.cm.SetOwnerReferences([]metav1.OwnerReference{
+			{
+				APIVersion: "krakend.nais.io/v1",
+				Kind:       "Krakend",
+				Name:       k.Name,
+				UID:        k.UID,
+			},
+		})
+
 		Expect(k8sClient.Create(ctx, apiEndpointsDeps.cm)).Should(Succeed())
 	})
 

--- a/internal/controller/krakend_controller.go
+++ b/internal/controller/krakend_controller.go
@@ -113,7 +113,6 @@ func (r *KrakendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		log.Debugf("creating resource of kind: %s with name: %s", resource.GetKind(), resource.GetName())
 
 		if resource.GetKind() == "Deployment" {
-			addAnnotations(resource, map[string]string{"reloader.stakater.com/search": "true"})
 			d := &v1.Deployment{}
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, d)
 			if err != nil {
@@ -138,8 +137,6 @@ func (r *KrakendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 
 		if resource.GetKind() == "ConfigMap" {
-			addAnnotations(resource, map[string]string{"reloader.stakater.com/match": "true"})
-
 			var cm corev1.ConfigMap
 			err := r.Get(ctx, types.NamespacedName{
 				Name:      resource.GetName(),
@@ -181,17 +178,6 @@ func (r *KrakendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func addAnnotations(resource *unstructured.Unstructured, annotations map[string]string) {
-	existing := resource.GetAnnotations()
-	if existing == nil {
-		existing = make(map[string]string)
-	}
-	for k, v := range annotations {
-		existing[k] = v
-	}
-	resource.SetAnnotations(existing)
 }
 
 func prepareValues(k *krakendv1.Krakend) (map[string]any, error) {

--- a/internal/controller/krakend_controller.go
+++ b/internal/controller/krakend_controller.go
@@ -128,6 +128,7 @@ func (r *KrakendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				d.Spec.Template.Spec.Containers[0].Env = existing
 			}
 			d.Spec.Template.Annotations["kubectl.kubernetes.io/default-container"] = d.Name
+			delete(d.Annotations, "checksum/cm-partials")
 
 			m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
 			if err != nil {


### PR DESCRIPTION
In order to reload configuration, being set by the Operator, Krakend must be restarted.

Previously, @nais made use of [stakater/Reloader](https://github.com/stakater/Reloader) to perform the restart **outside the Operator**, by watching ConfigMaps **generated by the Operator**.

I found it a bit silly to have separate operator to have deployment restart aligned with the changes made by another operator.

This PR implements logic to unset `checksum/cm-partials` Annotation set by [the Deployment manifest template in equinixmetal-helm/krakend chart repository](https://github.com/equinixmetal-helm/krakend/blob/main/templates/deployment.yaml#L32) used by the Operator to deploy Krakend itself.

When ApiEndpoints controller of the Operator generates and writes proper -partials ConfigMap, corresponding annotation being set, causing the Deployment to perform rollout restart.
